### PR TITLE
Fix Bug Where Blank Params Get Escaped Even When `{:esc :don't}`

### DIFF
--- a/src/inquery/core.cljc
+++ b/src/inquery/core.cljc
@@ -51,7 +51,6 @@
     (into {} (for [[k v] params]
                [k (cond
                     (treat-as? k v) (-> v :as str) ;; "no escape"
-                    (= v "") "''"
                     (string? v) (esc v)
                     (nil? v) "null"
                     :else (str v))]))))


### PR DESCRIPTION
Fixes #2 