### PR TITLE
Avoid Reflection When Checking Predicates

### DIFF
--- a/src/inquery/pred.cljc
+++ b/src/inquery/pred.cljc
@@ -4,7 +4,7 @@
 
 (defn check-pred [pred]
   (if (fn? pred)
-    (.invoke pred)
+    (pred)
     (throw (ex-info "predicate should be a function" {:instead-got pred}))))
 
 (defn value? [v]


### PR DESCRIPTION
If `pred` satisfies `fn?` then it should be safe enough to call it directly without resorting to unhinted `clojure.lang.IFn/invoke` reflective java interop:

```clojure
(set! *warn-on-reflection* true)
=> true

(defn check-pred-sans-type-hint [pred]
  (if (fn? pred)
    (.invoke pred)
    (throw (ex-info "predicate should be a function" {:instead-got pred}))))
Reflection warning, /path/to/scratch.clj:3:5 - reference to field invoke can't be resolved.
=> #'user/check-pred-sans-type-hint

(defn check-pred-type-hint-not-needed [pred]
  (if (fn? pred)
    (pred)
    (throw (ex-info "predicate should be a function" {:instead-got pred}))))
=> #'user/check-pred-type-hint-not-needed

(check-pred-sans-type-hint "not a fn!")
Execution error (ExceptionInfo) at user/check-pred-sans-type-hint (scratch.clj:4).
predicate should be a function

(try (check-pred-sans-type-hint (constantly (do (println "I was called!") false)))
     (catch Exception e
       (println "so sad! what when wrong?" e)))
I was called!
=> false

(check-pred-type-hint-not-needed "not a fn!")
Execution error (ExceptionInfo) at user/check-pred-type-hint-not-needed (scratch.clj:4).
predicate should be a function

(try (check-pred-type-hint-not-needed (constantly (do (println "I was called!") false)))
     (catch Exception e
       (println "so sad! what when wrong?" e)))
I was called!
=> false
```